### PR TITLE
Remove hardcoded targetframeworkversion

### DIFF
--- a/src/Starcounter.VS.CSApplicationProjectTemplate/ApplicationProjectTemplate.csproj
+++ b/src/Starcounter.VS.CSApplicationProjectTemplate/ApplicationProjectTemplate.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <AssemblyName>$safeprojectname$</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <StartWorkingDirectory>$(MSBuildProjectDirectory)</StartWorkingDirectory>

--- a/src/Starcounter.VS.CSClassLibraryProjectTemplate/ClassLibraryProjectTemplate.csproj
+++ b/src/Starcounter.VS.CSClassLibraryProjectTemplate/ClassLibraryProjectTemplate.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>$safeprojectname$</RootNamespace>
     <AssemblyName>$safeprojectname$</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <StarcounterVersionCompatibility>2.4</StarcounterVersionCompatibility>


### PR DESCRIPTION
This has the same changes (cherry picked the commit) as https://github.com/Starcounter/Starcounter.VisualStudio/pull/30 , but is for the `develop` branch.

It was approved in  https://github.com/Starcounter/Starcounter.VisualStudio/pull/30 - please see that PR for more details.